### PR TITLE
Core Organizer Context & Wiring (backend setup)

### DIFF
--- a/src/main/java/com/teame/config/AppConfig.java
+++ b/src/main/java/com/teame/config/AppConfig.java
@@ -6,10 +6,20 @@ import com.teame.service.ParticipantSession;
 import com.teame.service.PersonalityService;
 import com.teame.service.ValidationService;
 
+import com.teame.repository.CsvTeamRepository;
+import com.teame.repository.TeamRepository;
+import com.teame.concurrency.ConcurrencyService;
+import com.teame.service.TeamFormationService;
+import com.teame.service.OrganizerContext;
+
+
 public class AppConfig {
 
     private static final String PARTICIPANTS_FILE =
             "src/main/resources/com/teame/data/participants_saved.csv";
+
+    private static final String FORMED_TEAMS_FILE =
+            "src/main/resources/com/teame/data/formed_teams.csv";
 
     private final ParticipantSession participantSession = new ParticipantSession();
     private final ValidationService validationService = new ValidationService();
@@ -18,6 +28,15 @@ public class AppConfig {
             new CsvParticipantRepository(validationService);
     private final ParticipantService participantService =
             new ParticipantService(participantRepository, PARTICIPANTS_FILE);
+
+
+    // ---- New for organizer side ----
+    private final OrganizerContext organizerContext = new OrganizerContext();
+    private final ConcurrencyService concurrencyService =
+            new ConcurrencyService(personalityService, validationService);
+    private final TeamFormationService teamFormationService = new TeamFormationService();
+    private final TeamRepository teamRepository =
+            new CsvTeamRepository(FORMED_TEAMS_FILE);
 
     public ParticipantSession getParticipantSession() {
         return participantSession;
@@ -33,5 +52,23 @@ public class AppConfig {
 
     public ParticipantService getParticipantService() {
         return participantService;
+    }
+
+
+    // Organizer side getters
+    public OrganizerContext getOrganizerContext() {
+        return organizerContext;
+    }
+
+    public ConcurrencyService getConcurrencyService() {
+        return concurrencyService;
+    }
+
+    public TeamFormationService getTeamFormationService() {
+        return teamFormationService;
+    }
+
+    public TeamRepository getTeamRepository() {
+        return teamRepository;
     }
 }

--- a/src/main/java/com/teame/controller/common/RootLayoutController.java
+++ b/src/main/java/com/teame/controller/common/RootLayoutController.java
@@ -94,6 +94,27 @@ public class RootLayoutController {
         }
     }
 
+    // Organizer entry point (we'll make a dashboard in 7.2)
+    public void showOrganizerDashboard() {
+        // TODO: load organizer_dashboard.fxml and inject AppConfig + this
+    }
+
+    public void showOrganizerDataSource() {
+        // TODO in 7.3
+    }
+
+    public void showOrganizerInvalidRows() {
+        // TODO in 7.4
+    }
+
+    public void showOrganizerTeamFormation() {
+        // TODO in 7.5
+    }
+
+    public void showOrganizerViewTeams() {
+        // TODO in 7.6
+    }
+
 
 
 }

--- a/src/main/java/com/teame/repository/CsvTeamRepository.java
+++ b/src/main/java/com/teame/repository/CsvTeamRepository.java
@@ -12,8 +12,14 @@ import java.util.List;
 
 public class CsvTeamRepository implements TeamRepository {
 
+    private final String filePath;
+
+    public CsvTeamRepository(String filePath) {
+        this.filePath = filePath;
+    }
+
     @Override
-    public void saveAll(String filePath, List<Team> teams) {
+    public void saveAll(List<Team> teams) {
         List<String> lines = new ArrayList<>();
 
         // CSV header

--- a/src/main/java/com/teame/repository/TeamRepository.java
+++ b/src/main/java/com/teame/repository/TeamRepository.java
@@ -5,10 +5,6 @@ import com.teame.model.Team;
 import java.util.List;
 
 public interface TeamRepository {
-
-    /**
-     * Save all formed teams into a CSV file.
-     * Overwrites the file if it already exists.
-     */
-    void saveAll(String filePath, List<Team> teams);
+    void saveAll(List<Team> teams);
 }
+

--- a/src/main/java/com/teame/service/OrganizerContext.java
+++ b/src/main/java/com/teame/service/OrganizerContext.java
@@ -1,0 +1,72 @@
+package com.teame.service;
+
+import com.teame.model.Participant;
+import com.teame.model.Team;
+import com.teame.model.dto.InvalidRow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared state for organizer-side operations.
+ * Holds the currently loaded/cleaned participants, invalid rows, and formed teams.
+ */
+public class OrganizerContext {
+
+    private String sourceFilePath;
+
+    private final List<Participant> cleanedParticipants = new ArrayList<>();
+    private final List<InvalidRow> invalidRows = new ArrayList<>();
+    private final List<Team> formedTeams = new ArrayList<>();
+
+    public String getSourceFilePath() {
+        return sourceFilePath;
+    }
+
+    public void setSourceFilePath(String sourceFilePath) {
+        this.sourceFilePath = sourceFilePath;
+    }
+
+    // ---- Cleaned participants ----
+    public List<Participant> getCleanedParticipants() {
+        return cleanedParticipants;
+    }
+
+    public void setCleanedParticipants(List<Participant> participants) {
+        cleanedParticipants.clear();
+        if (participants != null) {
+            cleanedParticipants.addAll(participants);
+        }
+    }
+
+    // ---- Invalid rows ----
+    public List<InvalidRow> getInvalidRows() {
+        return invalidRows;
+    }
+
+    public void setInvalidRows(List<InvalidRow> rows) {
+        invalidRows.clear();
+        if (rows != null) {
+            invalidRows.addAll(rows);
+        }
+    }
+
+    // ---- Formed teams ----
+    public List<Team> getFormedTeams() {
+        return formedTeams;
+    }
+
+    public void setFormedTeams(List<Team> teams) {
+        formedTeams.clear();
+        if (teams != null) {
+            formedTeams.addAll(teams);
+        }
+    }
+
+    public void clearAll() {
+        sourceFilePath = null;
+        cleanedParticipants.clear();
+        invalidRows.clear();
+        formedTeams.clear();
+    }
+}


### PR DESCRIPTION
### Core Organizer Context & Wiring (backend setup)


- OrganizerContext (or OrganizerDataContext)

  - List<Participant> cleanedParticipants
  
  - List<InvalidRow> invalidRows
  
  - List<Team> formedTeams
  
  - maybe String sourceFilePath
  
- Extend AppConfig:
  
  - add OrganizerContext
  
  - add ConcurrencyService
  
  - add TeamFormationService
  
  - add TeamRepository / CsvTeamRepository

- Add navigation methods stubs in RootLayoutController:

  - showOrganizerDashboard()
  
  - showOrganizerDataSource()
  
  - showOrganizerInvalidRows()
  
  - showOrganizerTeamFormation()
  
  - showOrganizerViewTeams()